### PR TITLE
Fix link to example error handling scenario

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -3,7 +3,7 @@
 ## Background: Retry
 
 [Example
-scenario](https://docs.aws.amazon.com/step-functions/latest/dg/welcome.html)
+scenario](https://docs.aws.amazon.com/step-functions/latest/dg/welcome.html#welcome-error)
 for demonstrating the utility of retry:
 
 A customer requests a username. The first time, your customer’s request is


### PR DESCRIPTION
I think we want to link specifically to use case 3 in the AWS documentation. This PR just adjusts the link in the docs to use that scenario's anchor